### PR TITLE
Depend on requests>=2.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ META = {
         'testing': [
             'pytest>=2.4',
             'httplib2',
-            'requests'
+            'requests>=2.0.1'
         ],
     },
 }


### PR DESCRIPTION
requests.packages.urllib3.connection was added with 2.0.1 and is imported by wsgi_intercept/requests_intercept.py.
