### PR TITLE
Allow test suite to run on python3.2

### DIFF
--- a/test/test_wsgi_compliance.py
+++ b/test/test_wsgi_compliance.py
@@ -7,6 +7,15 @@ from test import wsgi_app
 import httplib2
 
 
+def _u(string_literal):
+    """Unicode literal shim allowing some tests to work in Python3.2.
+    """
+    if sys.version_info < (3, 0):
+        import codecs
+        return codecs.unicode_escape_decode(string_literal)[0]
+    return string_literal
+
+
 def http_install():
     install()
     wsgi_intercept.add_wsgi_intercept(
@@ -76,6 +85,6 @@ def test_encoding_errors():
     with py.test.raises(UnicodeEncodeError):
         response, content = http.request(
                 'http://some_hopefully_nonexistant_domain/boom/baz',
-                headers={'Accept': u'application/\u2603'})
+                headers={'Accept': _u('application/\u2603')})
 
     http_uninstall()


### PR DESCRIPTION
I personally don't care if 3.2 is actually supported, and this does add a bit of cruft. So closing it is not a problem. But in case it seems useful to let the test suite run on 3.2, here is a trivial patch for that.
