### PR TITLE
Test overhaul

### DIFF
--- a/test/install.py
+++ b/test/install.py
@@ -10,6 +10,19 @@ class BaseInstalledApp(object):
         self.script_name = script_name
         self._install = install or (lambda: None)
         self._uninstall = uninstall or (lambda: None)
+        self._hits = 0
+        self._internals = {}
+
+    def __call__(self, environ, start_response):
+        self._hits += 1
+        self._internals = environ
+        return self.app(environ, start_response)
+
+    def success(self):
+        return self._hits > 0
+
+    def get_internals(self):
+        return self._internals
 
     def install_wsgi_intercept(self):
         wsgi_intercept.add_wsgi_intercept(
@@ -27,11 +40,11 @@ class BaseInstalledApp(object):
         self._uninstall()
 
     def factory(self):
-        return self.app
+        return self
 
     def __enter__(self):
         self.install()
-        return self.app
+        return self
 
     def __exit__(self, *args, **kwargs):
         self.uninstall()

--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -13,8 +13,7 @@ InstalledApp = installer_class(http_client_intercept)
 
 
 def test_http_success():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.simple_app)
-    with InstalledApp(mock_app, host=HOST, port=80) as app:
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=80) as app:
         http_client = http_lib.HTTPConnection(HOST)
         http_client.request('GET', '/')
         content = http_client.getresponse().read()
@@ -23,8 +22,7 @@ def test_http_success():
 
 
 def test_https_success():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.simple_app)
-    with InstalledApp(mock_app, host=HOST, port=443) as app:
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
         http_client = http_lib.HTTPSConnection(HOST)
         http_client.request('GET', '/')
         content = http_client.getresponse().read()
@@ -33,8 +31,7 @@ def test_https_success():
 
 
 def test_app_error():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.raises_app)
-    with InstalledApp(mock_app, host=HOST, port=80):
+    with InstalledApp(wsgi_app.raises_app, host=HOST, port=80):
         http_client = http_lib.HTTPConnection(HOST)
         with py.test.raises(WSGIAppError):
             http_client.request('GET', '/')

--- a/test/test_httplib2.py
+++ b/test/test_httplib2.py
@@ -11,8 +11,7 @@ InstalledApp = installer_class(httplib2_intercept)
 
 
 def test_success():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.simple_app)
-    with InstalledApp(mock_app, host=HOST, port=80) as app:
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=80) as app:
         http = httplib2.Http()
         resp, content = http.request(
             'http://some_hopefully_nonexistant_domain:80/')
@@ -21,24 +20,21 @@ def test_success():
 
 
 def test_bogus_domain():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.simple_app)
-    with InstalledApp(mock_app, host=HOST, port=80):
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=80):
         py.test.raises(
             gaierror,
             'httplib2_intercept.HTTP_WSGIInterceptorWithTimeout("_nonexistant_domain_").connect()')
 
 
 def test_https_success():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.simple_app)
-    with InstalledApp(mock_app, host=HOST, port=443) as app:
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
         http = httplib2.Http()
         resp, content = http.request('https://some_hopefully_nonexistant_domain/')
         assert app.success()
 
 
 def test_app_error():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.raises_app)
-    with InstalledApp(mock_app, host=HOST, port=80):
+    with InstalledApp(wsgi_app.raises_app, host=HOST, port=80):
         http = httplib2.Http()
         with py.test.raises(WSGIAppError):
             http.request(

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -11,31 +11,27 @@ InstalledApp = installer_class(requests_intercept)
 
 
 def test_success():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.simple_app)
-    with InstalledApp(mock_app, host=HOST, port=80) as app:
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=80) as app:
         resp = requests.get('http://some_hopefully_nonexistant_domain:80/')
         assert resp.content == b'WSGI intercept successful!\n'
         assert app.success()
 
 
 def test_bogus_domain():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.simple_app)
-    with InstalledApp(mock_app, host=HOST, port=80):
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=80):
         py.test.raises(
             ConnectionError,
             'requests.get("http://_nonexistant_domain_")')
 
 
 def test_https_success():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.simple_app)
-    with InstalledApp(mock_app, host=HOST, port=443) as app:
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
         resp = requests.get('https://some_hopefully_nonexistant_domain/')
         assert resp.content == b'WSGI intercept successful!\n'
         assert app.success()
 
 
 def test_app_error():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.raises_app)
-    with InstalledApp(mock_app, host=HOST, port=80):
+    with InstalledApp(wsgi_app.raises_app, host=HOST, port=80):
         with py.test.raises(WSGIAppError):
             requests.get('http://some_hopefully_nonexistant_domain:80/')

--- a/test/test_urllib.py
+++ b/test/test_urllib.py
@@ -13,35 +13,30 @@ InstalledApp = installer_class(install=urllib_intercept.install_opener)
 
 
 def test_http():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.simple_app)
-    with InstalledApp(mock_app, host=HOST, port=80) as app:
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=80) as app:
         url_lib.urlopen('http://some_hopefully_nonexistant_domain:80/')
         assert app.success()
 
 
 def test_http_default_port():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.simple_app)
-    with InstalledApp(mock_app, host=HOST, port=80) as app:
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=80) as app:
         url_lib.urlopen('http://some_hopefully_nonexistant_domain/')
         assert app.success()
 
 
 def test_https():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.simple_app)
-    with InstalledApp(mock_app, host=HOST, port=443) as app:
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
         url_lib.urlopen('https://some_hopefully_nonexistant_domain:443/')
         assert app.success()
 
 
 def test_https_default_port():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.simple_app)
-    with InstalledApp(mock_app, host=HOST, port=443) as app:
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
         url_lib.urlopen('https://some_hopefully_nonexistant_domain/')
         assert app.success()
 
 
 def test_app_error():
-    mock_app = wsgi_app.MockWSGIApp(wsgi_app.raises_app)
-    with InstalledApp(mock_app, host=HOST, port=80):
+    with InstalledApp(wsgi_app.raises_app, host=HOST, port=80):
         with py.test.raises(WSGIAppError):
             url_lib.urlopen('http://some_hopefully_nonexistant_domain:80/')

--- a/test/test_wsgi_compliance.py
+++ b/test/test_wsgi_compliance.py
@@ -11,8 +11,7 @@ InstalledApp = installer_class(httplib2_intercept)
 
 
 def test_simple_override():
-    mock_simple_app = wsgi_app.MockWSGIApp(wsgi_app.simple_app)
-    with InstalledApp(mock_simple_app, host=HOST) as app:
+    with InstalledApp(wsgi_app.simple_app, host=HOST) as app:
         http = httplib2.Http()
         resp, content = http.request(
             'http://some_hopefully_nonexistant_domain:80/', 'GET')
@@ -20,8 +19,7 @@ def test_simple_override():
 
 
 def test_more_interesting():
-    mock_more_interesting_app = wsgi_app.MockWSGIApp(wsgi_app.more_interesting_app)
-    with InstalledApp(mock_more_interesting_app, host=HOST) as app:
+    with InstalledApp(wsgi_app.more_interesting_app, host=HOST) as app:
         http = httplib2.Http()
         resp, content = http.request(
             'http://some_hopefully_nonexistant_domain/%E4%B8%96%E4%B8%8A%E5%8E%9F%E4%BE%86%E9%82%84%E6%9C%89%E3%80%8C%E7%BE%9A%E7%89%9B%E3%80%8D%E9%80%99%E7%A8%AE%E5%8B%95%E7%89%A9%EF%BC%81%2Fbarney?bar=baz%20zoom',
@@ -35,9 +33,8 @@ def test_more_interesting():
 
 
 def test_script_name():
-    mock_more_interesting_app = wsgi_app.MockWSGIApp(wsgi_app.more_interesting_app)
-    with InstalledApp(
-            mock_more_interesting_app, host=HOST, script_name='/funky') as app:
+    with InstalledApp(wsgi_app.more_interesting_app, host=HOST,
+                      script_name='/funky') as app:
         http = httplib2.Http()
         response, content = http.request(
             'http://some_hopefully_nonexistant_domain/funky/boom/baz')
@@ -51,8 +48,7 @@ def test_script_name():
     sys.version_info[0] == 2 and sys.version_info[1] <= 6,
     reason='works okay on 2.7 and beyond. why?')
 def test_encoding_errors():
-    mock_more_interesting_app = wsgi_app.MockWSGIApp(wsgi_app.more_interesting_app)
-    with InstalledApp(mock_more_interesting_app, host=HOST):
+    with InstalledApp(wsgi_app.more_interesting_app, host=HOST):
         http = httplib2.Http()
         with py.test.raises(UnicodeEncodeError):
             response, content = http.request(

--- a/test/wsgi_app.py
+++ b/test/wsgi_app.py
@@ -10,24 +10,6 @@ except ImportError:
     bytes = str
 
 
-class MockWSGIApp(object):
-    def __init__(self, app):
-        self._app = app
-        self._hits = 0
-        self._internals = {}
-
-    def __call__(self, environ, start_response):
-        self._hits += 1
-        self._internals = environ
-        return self._app(environ, start_response)
-
-    def success(self):
-        return self._hits > 0
-
-    def get_internals(self):
-        return self._internals
-
-
 def simple_app(environ, start_response):
     """Simplest possible application object"""
     status = '200 OK'


### PR DESCRIPTION
This branch reduces the amount of global state that tests share with each other (from test.wsgi_app) by using a mock app object instead of module globals. It also uses a context manager to regularize the way intercept install/uninstall is done in tests, do a better job ensuring uninstalls occur, and reduce the boilerplate for install/uninstall inside new tests.

This is intended to make the unit tests a little more deterministic, and to make it slightly less painful to add a new test for all the intercept backends, or to add a new set of tests for a new intercept backend.
