### PR TITLE
do away with explicit port 80 in test URLs

### DIFF
--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -12,7 +12,7 @@ HOST = 'some_hopefully_nonexistant_domain'
 InstalledApp = installer_class(http_client_intercept)
 
 
-def test_http_success():
+def test_http():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=80) as app:
         http_client = http_lib.HTTPConnection(HOST)
         http_client.request('GET', '/')
@@ -22,7 +22,7 @@ def test_http_success():
         assert app.success()
 
 
-def test_https_success():
+def test_https():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
         http_client = http_lib.HTTPSConnection(HOST)
         http_client.request('GET', '/')

--- a/test/test_httplib2.py
+++ b/test/test_httplib2.py
@@ -10,11 +10,20 @@ HOST = 'some_hopefully_nonexistant_domain'
 InstalledApp = installer_class(httplib2_intercept)
 
 
-def test_success():
+def test_http():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=80) as app:
         http = httplib2.Http()
         resp, content = http.request(
             'http://some_hopefully_nonexistant_domain:80/')
+        assert content == b'WSGI intercept successful!\n'
+        assert app.success()
+
+
+def test_http_default_port():
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=80) as app:
+        http = httplib2.Http()
+        resp, content = http.request(
+            'http://some_hopefully_nonexistant_domain/')
         assert content == b'WSGI intercept successful!\n'
         assert app.success()
 
@@ -26,7 +35,14 @@ def test_bogus_domain():
             'httplib2_intercept.HTTP_WSGIInterceptorWithTimeout("_nonexistant_domain_").connect()')
 
 
-def test_https_success():
+def test_https():
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
+        http = httplib2.Http()
+        resp, content = http.request('https://some_hopefully_nonexistant_domain:443/')
+        assert app.success()
+
+
+def test_https_default_port():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
         http = httplib2.Http()
         resp, content = http.request('https://some_hopefully_nonexistant_domain/')
@@ -38,4 +54,4 @@ def test_app_error():
         http = httplib2.Http()
         with py.test.raises(WSGIAppError):
             http.request(
-                'http://some_hopefully_nonexistant_domain:80/')
+                'http://some_hopefully_nonexistant_domain/')

--- a/test/test_mechanize_intercept.py
+++ b/test/test_mechanize_intercept.py
@@ -27,13 +27,24 @@ else:
 
 HOST = 'some_hopefully_nonexistent_domain'
 
-ONLY_PYTHON2_NOT_PYPY = py.test.mark.skipif(not CAN_RUN_TESTS,
-    reason="mechanize is not ported from Python 2 and fails in PyPy"
-)
+ONLY_PYTHON2_NOT_PYPY = py.test.mark.skipif(
+    not CAN_RUN_TESTS,
+    reason="mechanize is not ported from Python 2 and fails in PyPy")
 
 
 @ONLY_PYTHON2_NOT_PYPY
-def test_success():
+def test_http():
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=80) as app:
+        browser = mechanize.Browser()
+        url = 'http://some_hopefully_nonexistent_domain:80'
+        response = browser.open(url)
+        content = response.read()
+        assert content == b'WSGI intercept successful!\n'
+        assert app.success()
+
+
+@ONLY_PYTHON2_NOT_PYPY
+def test_http_default_port():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=80) as app:
         browser = mechanize.Browser()
         url = 'http://some_hopefully_nonexistent_domain'
@@ -52,10 +63,20 @@ def test_bogus_domain():
 
 
 @ONLY_PYTHON2_NOT_PYPY
-def test_https_success():
+def test_https():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
         browser = mechanize.Browser()
         response = browser.open('https://some_hopefully_nonexistent_domain')
+        content = response.read()
+        assert content == b'WSGI intercept successful!\n'
+        assert app.success()
+
+
+@ONLY_PYTHON2_NOT_PYPY
+def test_https_default_port():
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
+        browser = mechanize.Browser()
+        response = browser.open('https://some_hopefully_nonexistent_domain:443')
         content = response.read()
         assert content == b'WSGI intercept successful!\n'
         assert app.success()

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -10,9 +10,16 @@ HOST = 'some_hopefully_nonexistant_domain'
 InstalledApp = installer_class(requests_intercept)
 
 
-def test_success():
+def test_http():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=80) as app:
         resp = requests.get('http://some_hopefully_nonexistant_domain:80/')
+        assert resp.content == b'WSGI intercept successful!\n'
+        assert app.success()
+
+
+def test_http_default_port():
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=80) as app:
+        resp = requests.get('http://some_hopefully_nonexistant_domain/')
         assert resp.content == b'WSGI intercept successful!\n'
         assert app.success()
 
@@ -24,7 +31,14 @@ def test_bogus_domain():
             'requests.get("http://_nonexistant_domain_")')
 
 
-def test_https_success():
+def test_https():
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
+        resp = requests.get('https://some_hopefully_nonexistant_domain:443/')
+        assert resp.content == b'WSGI intercept successful!\n'
+        assert app.success()
+
+
+def test_https_default_port():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
         resp = requests.get('https://some_hopefully_nonexistant_domain/')
         assert resp.content == b'WSGI intercept successful!\n'
@@ -34,7 +48,7 @@ def test_https_success():
 def test_app_error():
     with InstalledApp(wsgi_app.raises_app, host=HOST, port=80):
         with py.test.raises(WSGIAppError):
-            requests.get('http://some_hopefully_nonexistant_domain:80/')
+            requests.get('http://some_hopefully_nonexistant_domain/')
 
 
 def test_http_not_intercepted():

--- a/test/test_urllib.py
+++ b/test/test_urllib.py
@@ -39,4 +39,4 @@ def test_https_default_port():
 def test_app_error():
     with InstalledApp(wsgi_app.raises_app, host=HOST, port=80):
         with py.test.raises(WSGIAppError):
-            url_lib.urlopen('http://some_hopefully_nonexistant_domain:80/')
+            url_lib.urlopen('http://some_hopefully_nonexistant_domain/')

--- a/test/test_wsgi_compliance.py
+++ b/test/test_wsgi_compliance.py
@@ -18,6 +18,14 @@ def test_simple_override():
         assert app.success()
 
 
+def test_simple_override_default_port():
+    with InstalledApp(wsgi_app.simple_app, host=HOST) as app:
+        http = httplib2.Http()
+        resp, content = http.request(
+            'http://some_hopefully_nonexistant_domain/', 'GET')
+        assert app.success()
+
+
 def test_more_interesting():
     with InstalledApp(wsgi_app.more_interesting_app, host=HOST) as app:
         http = httplib2.Http()


### PR DESCRIPTION
I don't think it is a big issue in practice, but explicit port 80 is relatively uncommon and I am very slightly concerned that tests requiring it may fail without it. At your option.
