### PR TITLE
Restore a single SP precedding the field value

### DIFF
--- a/wsgi_intercept/__init__.py
+++ b/wsgi_intercept/__init__.py
@@ -369,7 +369,7 @@ class wsgi_fake_socket:
                     v = v.encode('utf-8')
                 except AttributeError:
                     pass
-                self.output.write(k + b':' + v + b"\n")
+                self.output.write(k + b': ' + v + b"\n")
             self.output.write(b'\n')
 
             def write_fn(s):


### PR DESCRIPTION
This is preferred by RFC.
http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2

This also restores doctest compatibility which is using wsgi 0.5.x series.

Wsgi intercept is used by https://launchpad.net in doctests by most of its components, which have picked up this behavioural change in 0.6.x series. Currently wsgi_intercept is pinned at 0.5.1 in launchpad's buildouts, but I would like to migrated to latest wsgi_intercept. Please consider merging this and making a point release to pypi.

I will applying this change in Debian & Ubuntu packaging as well.
