### PR TITLE
lame strict handling on behalf of old urllib3 in Debian

### DIFF
--- a/wsgi_intercept/requests_intercept.py
+++ b/wsgi_intercept/requests_intercept.py
@@ -1,6 +1,6 @@
 """Intercept HTTP connections that use `requests <http://docs.python-requests.org/en/latest/>`_.
 """
-
+import sys
 from . import WSGI_HTTPConnection, WSGI_HTTPSConnection, wsgi_fake_socket
 from requests.packages.urllib3.connectionpool import (HTTPConnectionPool,
         HTTPSConnectionPool)
@@ -12,11 +12,19 @@ wsgi_fake_socket.settimeout = lambda self, timeout: None
 
 
 class HTTP_WSGIInterceptor(WSGI_HTTPConnection, HTTPConnection):
-    pass
+    def __init__(self, *args, **kwargs):
+        if 'strict' in kwargs and sys.version_info > (3, 0):
+            kwargs.pop('strict')
+        WSGI_HTTPConnection.__init__(self, *args, **kwargs)
+        HTTPConnection.__init__(self, *args, **kwargs)
 
 
 class HTTPS_WSGIInterceptor(WSGI_HTTPSConnection, HTTPSConnection):
-    pass
+    def __init__(self, *args, **kwargs):
+        if 'strict' in kwargs and sys.version_info > (3, 0):
+            kwargs.pop('strict')
+        WSGI_HTTPSConnection.__init__(self, *args, **kwargs)
+        HTTPSConnection.__init__(self, *args, **kwargs)
 
 
 def install():


### PR DESCRIPTION
Should we want to merge it, this lame PR should let wsgi_intercept run interference for Debian Sid's older urllib3 that it unvendored from requests. Passed tests in all envs on my local machine, in python2.7 and python3.4 virtualenvs on Debian Sid VM, and with python3.4 -m pytest under Debian Sid (no virtualenv, dependencies from apt-get including urllib3 1.8.3).
However, in the last environment there is still an unrelated problem with referencing 'requests.packages.urllib3' instead of 'urllib3' because Debian moved it, my test patched that to just import from urllib3 directly on the assumption this will be a patch maintained on Debian's side since it is their policy which unvendors urllib3, not ours.
