### PR TITLE
Fixed InsecureRequestWarning from urllib3

### DIFF
--- a/wsgi_intercept/requests_intercept.py
+++ b/wsgi_intercept/requests_intercept.py
@@ -22,6 +22,8 @@ class HTTP_WSGIInterceptor(WSGI_HTTPConnection, HTTPConnection):
 
 
 class HTTPS_WSGIInterceptor(WSGI_HTTPSConnection, HTTPSConnection):
+    is_verified = True
+
     def __init__(self, *args, **kwargs):
         if 'strict' in kwargs and sys.version_info > (3, 0):
             kwargs.pop('strict')


### PR DESCRIPTION
urllib3 0.9 added a really annoying [`InsecureRequestWarning`](https://urllib3.readthedocs.org/en/latest/security.html#insecurerequestwarning) and thinks intercepted requests are unverified.

This patch fixes the problem for me and passes the tests.
