### PR TITLE
Guard against http_proxy and https_proxy

### DIFF
--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -42,6 +42,18 @@ def test_other():
         assert app.success()
 
 
+def test_proxy_handling():
+    """Proxy variable no impact."""
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=80,
+                      proxy='some.host:1234') as app:
+        http_client = http_lib.HTTPConnection(HOST)
+        http_client.request('GET', '/')
+        content = http_client.getresponse().read()
+        http_client.close()
+        assert content == b'WSGI intercept successful!\n'
+        assert app.success()
+
+
 def test_app_error():
     with InstalledApp(wsgi_app.raises_app, host=HOST, port=80):
         http_client = http_lib.HTTPConnection(HOST)

--- a/test/test_httplib2.py
+++ b/test/test_httplib2.py
@@ -47,6 +47,17 @@ def test_bogus_domain():
             'httplib2_intercept.HTTP_WSGIInterceptorWithTimeout("_nonexistant_domain_").connect()')
 
 
+def test_proxy_handling():
+    """Proxy has no impact."""
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=80,
+                      proxy='some_proxy.com:1234') as app:
+        http = httplib2.Http()
+        resp, content = http.request(
+            'http://some_hopefully_nonexistant_domain:80/')
+        assert content == b'WSGI intercept successful!\n'
+        assert app.success()
+
+
 def test_https():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
         http = httplib2.Http()

--- a/wsgi_intercept/__init__.py
+++ b/wsgi_intercept/__init__.py
@@ -50,6 +50,11 @@ Note especially that ``app_create_fn`` is a *function object* returning a WSGI
 application; ``script_name`` becomes ``SCRIPT_NAME`` in the WSGI app's
 environment, if set.
 
+Note also that if ``http_proxy`` or ``https_proxy`` is set in the environment
+this can cause difficulties with some of the intercepted libraries. If 
+requests or urllib is being used, these will raise an exception if one of
+those variables is set.
+
 Install
 =======
 

--- a/wsgi_intercept/requests_intercept.py
+++ b/wsgi_intercept/requests_intercept.py
@@ -1,6 +1,7 @@
 """Intercept HTTP connections that use `requests <http://docs.python-requests.org/en/latest/>`_.
 """
 
+import os
 import sys
 
 from . import WSGI_HTTPConnection, WSGI_HTTPSConnection, wsgi_fake_socket
@@ -32,6 +33,9 @@ class HTTPS_WSGIInterceptor(WSGI_HTTPSConnection, HTTPSConnection):
 
 
 def install():
+    if 'http_proxy' in os.environ or 'https_proxy' in os.environ:
+        raise RuntimeError(
+            'http_proxy or https_proxy set in environment, please unset')
     HTTPConnectionPool.ConnectionCls = HTTP_WSGIInterceptor
     HTTPSConnectionPool.ConnectionCls = HTTPS_WSGIInterceptor
 

--- a/wsgi_intercept/urllib_intercept.py
+++ b/wsgi_intercept/urllib_intercept.py
@@ -1,5 +1,8 @@
 """Intercept HTTP connections that use urllib.request (Py3) aka urllib2 (Python 2).
 """
+
+import os
+
 try:
     import urllib.request as url_lib
 except ImportError:
@@ -27,6 +30,9 @@ class WSGI_HTTPSHandler(url_lib.HTTPSHandler):
 
 
 def install_opener():
+    if 'http_proxy' in os.environ or 'https_proxy' in os.environ:
+        raise RuntimeError(
+            'http_proxy or https_proxy set in environment, please unset')
     handlers = [WSGI_HTTPHandler()]
     if WSGI_HTTPSHandler is not None:
         handlers.append(WSGI_HTTPSHandler())


### PR DESCRIPTION
requests and urllib will get upset of socks proxy settings are
present in the environment. In those interceptors, an exception
will now be raised if $http_proxy or $https_proxy are set.

Tests are added to cover the variable being set for all four
of the interceptor types.

This is the quick and dirty solution to the problem. The way this
has been done shows some clear opportunities for refactoring down
the road.

Fixes #30