### PR TITLE
Skip the network tests if WSGI_INTERCEPT_SKIP_NETWORK

### DIFF
--- a/test/README
+++ b/test/README
@@ -1,0 +1,6 @@
+
+If you wish to run the tests without those tests which speak to
+the internet (there are a few that validate that the intercept
+does not intercept). Set the WSGI_INTERCEPT_SKIP_NETWORK environment
+variable to "True". Any other value or no value will mean that
+the network tests will run.

--- a/test/install.py
+++ b/test/install.py
@@ -1,5 +1,12 @@
 import os
+import pytest
 import wsgi_intercept
+
+
+skipnetwork = pytest.mark.skipif(os.environ.get(
+    'WSGI_INTERCEPT_SKIP_NETWORK', 'False').lower() == 'true',
+    reason="skip network requested"
+)
 
 
 class BaseInstalledApp(object):

--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -1,7 +1,7 @@
 import py.test
 from wsgi_intercept import http_client_intercept, WSGIAppError
 from test import wsgi_app
-from test.install import installer_class
+from test.install import installer_class, skipnetwork
 try:
     import http.client as http_lib
 except ImportError:
@@ -63,6 +63,7 @@ def test_app_error():
         http_client.close()
 
 
+@skipnetwork
 def test_http_not_intercepted():
     with InstalledApp(wsgi_app.raises_app, host=HOST, port=80):
         http_client = http_lib.HTTPConnection('google.com')
@@ -72,6 +73,7 @@ def test_http_not_intercepted():
         assert 200 <= int(response.status) < 400
 
 
+@skipnetwork
 def test_https_not_intercepted():
     with InstalledApp(wsgi_app.raises_app, host=HOST, port=443):
         http_client = http_lib.HTTPSConnection('google.com')

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -2,7 +2,7 @@ import os
 import py.test
 from wsgi_intercept import requests_intercept, WSGIAppError
 from test import wsgi_app
-from test.install import installer_class
+from test.install import installer_class, skipnetwork
 import requests
 from requests.exceptions import ConnectionError
 
@@ -75,12 +75,14 @@ def test_app_error():
             requests.get('http://some_hopefully_nonexistant_domain/')
 
 
+@skipnetwork
 def test_http_not_intercepted():
     with InstalledApp(wsgi_app.raises_app, host=HOST, port=80):
         resp = requests.get("http://google.com")
         assert resp.status_code >= 200 and resp.status_code < 300
 
 
+@skipnetwork
 def test_https_not_intercepted():
     with InstalledApp(wsgi_app.raises_app, host=HOST, port=80):
         resp = requests.get("https://google.com")

--- a/test/test_urllib.py
+++ b/test/test_urllib.py
@@ -2,7 +2,7 @@ import os
 import py.test
 from wsgi_intercept import urllib_intercept, WSGIAppError
 from test import wsgi_app
-from test.install import installer_class
+from test.install import installer_class, skipnetwork
 try:
     import urllib.request as url_lib
 except ImportError:
@@ -66,12 +66,14 @@ def test_app_error():
             url_lib.urlopen('http://some_hopefully_nonexistant_domain/')
 
 
+@skipnetwork
 def test_http_not_intercepted():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=80):
         response = url_lib.urlopen('http://google.com/')
         assert 200 <= int(response.code) < 400
 
 
+@skipnetwork
 def test_https_not_intercepted():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=443):
         response = url_lib.urlopen('https://google.com/')


### PR DESCRIPTION
This allows the tests to work in a reasonable way in
network disconnected situations.

Fixes #36