### PR TITLE
Correctly handler a url argument to interceptor with no port

### DIFF
--- a/test/test_interceptor.py
+++ b/test/test_interceptor.py
@@ -45,6 +45,19 @@ def test_interceptor_instance():
     assert interceptor.url == 'http://%s:%s/foobar' % (hostname, port)
 
 
+def test_intercept_by_url_no_port():
+    # Test for https://github.com/cdent/wsgi-intercept/issues/41
+    hostname = str(uuid4())
+    url = 'http://%s/foobar' % hostname
+    interceptor = Httplib2Interceptor(app=app, url=url)
+    assert isinstance(interceptor, Interceptor)
+    assert interceptor.app == app
+    assert interceptor.host == hostname
+    assert interceptor.port == 80
+    assert interceptor.script_name == '/foobar'
+    assert interceptor.url == url
+
+
 # http_lib
 
 def test_httpclient_interceptor_host():

--- a/wsgi_intercept/interceptor.py
+++ b/wsgi_intercept/interceptor.py
@@ -66,8 +66,12 @@ class Interceptor(object):
                                     None, None))
 
     def _init_from_url(self, url):
+        port = None
         parsed_url = urlparse.urlsplit(url)
-        host, port = parsed_url.netloc.split(':')
+        if ':' in parsed_url.netloc:
+            host, port = parsed_url.netloc.split(':')
+        else:
+            host = parsed_url.netloc
         if not port:
             if parsed_url.scheme == 'https':
                 port = 443


### PR DESCRIPTION
Fixes #41

Without this the split fails when there is no : in netloc.