### PR TITLE
Accept an empty string from a wsgi iterator

### DIFF
--- a/wsgi_intercept/__init__.py
+++ b/wsgi_intercept/__init__.py
@@ -487,7 +487,7 @@ class wsgi_fake_socket:
                 for data in self.write_results:
                     self.output.write(data)
 
-            if generator_data:
+            if generator_data is not None:
                 try:
                     self.output.write(generator_data)
                 except TypeError as exc:

--- a/wsgi_intercept/tests/test_response_headers.py
+++ b/wsgi_intercept/tests/test_response_headers.py
@@ -28,7 +28,7 @@ class HeaderApp(object):
         for header in self.headers:
             headers.append((header, self.headers[header]))
         start_response('200 OK', headers)
-        return ['']
+        return [b'']
 
 
 def app(headers):

--- a/wsgi_intercept/tests/test_wsgi_compliance.py
+++ b/wsgi_intercept/tests/test_wsgi_compliance.py
@@ -105,3 +105,12 @@ def test_post_status_headers():
             'http://some_hopefully_nonexistant_domain/', 'GET')
         assert app.success()
         assert resp.get('content-type') == 'text/plain'
+
+
+def test_empty_iterator():
+    with InstalledApp(wsgi_app.empty_string_app, host=HOST) as app:
+        http = httplib2.Http()
+        resp, content = http.request(
+            'http://some_hopefully_nonexistant_domain/', 'GET')
+        assert app.success()
+        assert content == b'second'

--- a/wsgi_intercept/tests/wsgi_app.py
+++ b/wsgi_intercept/tests/wsgi_app.py
@@ -32,3 +32,8 @@ def post_status_headers_app(environ, start_response):
 
 def raises_app(environ, start_response):
     raise TypeError("bah")
+
+
+def empty_string_app(environ, start_response):
+    start_response('200 OK', [('Content-type', 'text/plain')])
+    return [b'', b'second']


### PR DESCRIPTION
This is allowed by the pep but the code was written such that if it
received an empty string it would not get the rest of the iterator.
This change fixes it so only None will cause the stop.

With this change an unrelated test wsgi app which was returning an
empty string needed to be fixed to return a bytestring.

Fixes #46