### PR TITLE
Ignore `socket_options` for urllib3

### DIFF
--- a/wsgi_intercept/_urllib3.py
+++ b/wsgi_intercept/_urllib3.py
@@ -16,6 +16,7 @@ def make_urllib3_override(HTTPConnectionPool, HTTPSConnectionPool,
         def __init__(self, *args, **kwargs):
             if 'strict' in kwargs and sys.version_info > (3, 0):
                 kwargs.pop('strict')
+            kwargs.pop('socket_options', None)
             WSGI_HTTPConnection.__init__(self, *args, **kwargs)
             HTTPConnection.__init__(self, *args, **kwargs)
 
@@ -25,6 +26,7 @@ def make_urllib3_override(HTTPConnectionPool, HTTPSConnectionPool,
         def __init__(self, *args, **kwargs):
             if 'strict' in kwargs and sys.version_info > (3, 0):
                 kwargs.pop('strict')
+            kwargs.pop('socket_options', None)
             WSGI_HTTPSConnection.__init__(self, *args, **kwargs)
             HTTPSConnection.__init__(self, *args, **kwargs)
 

--- a/wsgi_intercept/tests/test_urllib3.py
+++ b/wsgi_intercept/tests/test_urllib3.py
@@ -74,6 +74,14 @@ def test_https_default_port():
         assert environ['wsgi.url_scheme'] == 'https'
 
 
+def test_socket_options():
+    http = urllib3.PoolManager(socket_options=[])
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=80):
+        http.request('GET', 'http://some_hopefully_nonexistant_domain/')
+    with InstalledApp(wsgi_app.simple_app, host=HOST, port=443):
+        http.request('GET', 'https://some_hopefully_nonexistant_domain/')
+
+
 def test_app_error():
     with InstalledApp(wsgi_app.raises_app, host=HOST, port=80):
         with py.test.raises(WSGIAppError):


### PR DESCRIPTION
`urllib3` allows the keyword argument `socket_options` in its `HTTPConnection`. `wsgi_intercept` should ignore this parameter, like how it ignores `strict`.