### PR TITLE
Use matrix for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,29 @@
 sudo: false
 language: python
-python:
-      - "3.5"
 install:
       - pip install tox
 script:
       - tox
-env:
-      - TOXENV=py27
-      - TOXENV=py33
-      - TOXENV=py34
-      - TOXENV=py35
-      - TOXENV=pypy
-      - TOXENV=pep8
-      - TOXENV=docs
+matrix:
+    include:
+        - python: 2.7
+          env: TOXENV=py27
+        - python: 2.7
+          env: TOXENV=pep8
+        - python: 2.7
+          env: TOXENV=docs
+        - python: 3.3
+          env: TOXENV=py33
+        - python: 3.4
+          env: TOXENV=py34
+        - python: 3.5
+          env: TOXENV=py35
+        - python: 3.6
+          env: TOXENV=py36
+        - python: pypy
+          env: TOXENV=pypy
+        - python: pypy3
+          env: TOXENV=pypy3
 
 notifications:
       irc: "chat.freenode.net#gabbi"


### PR DESCRIPTION
This allows finer grained control over which python is used
for which tox targets.