### PR TITLE
Allow nested interceptor context managers

### DIFF
--- a/wsgi_intercept/__init__.py
+++ b/wsgi_intercept/__init__.py
@@ -201,6 +201,7 @@ def remove_wsgi_intercept(*args):
         key = (args[0], args[1])
         if key in _wsgi_intercept:
             del _wsgi_intercept[key]
+    return len(_wsgi_intercept)
 
 
 #

--- a/wsgi_intercept/interceptor.py
+++ b/wsgi_intercept/interceptor.py
@@ -91,7 +91,13 @@ class Interceptor(object):
                                           script_name=self.script_name)
 
     def uninstall_intercept(self):
-        wsgi_intercept.remove_wsgi_intercept(self.host, self.port)
+        remaining = wsgi_intercept.remove_wsgi_intercept(self.host, self.port)
+        # Only remove the module's class overrides if there are no intercepts
+        # left. Otherwise nested context managers cannot work.
+        if not remaining:
+            self.uninstall_module()
+
+    def uninstall_module(self):
         self._module.uninstall()
 
 


### PR DESCRIPTION
The previous implementation of interceptor context managers would remove
the connection class overrides whenever a context manager exited. This
meant that if more than one interceptor was present others would stop
working when one was removed.

This only removes if there are no intercepts left.

Fixes #53