### PR TITLE
Updates for dependent library changes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py27,py33,py34,py35,py36,pypy,pep8,docs,readme
+envlist = py27,py35,py36,py37,pypy,pep8,docs,readme
 
 [testenv]
 deps = .[testing]

--- a/wsgi_intercept/httplib2_intercept.py
+++ b/wsgi_intercept/httplib2_intercept.py
@@ -32,8 +32,7 @@ class HTTPS_WSGIInterceptorWithTimeout(HTTPSInterceptorMixin,
         HTTPSConnectionWithTimeout):
     def __init__(self, host, port=None, strict=None, timeout=None,
             proxy_info=None, ca_certs=None, source_address=None,
-            disable_ssl_certificate_validation=False,
-            ssl_version=None):
+            **kwargs):
 
         # ignore proxy_info and ca_certs
         # In Python3 strict is deprecated

--- a/wsgi_intercept/tests/test_httplib2.py
+++ b/wsgi_intercept/tests/test_httplib2.py
@@ -42,10 +42,9 @@ def test_http_other_port():
 
 def test_bogus_domain():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=80):
-        py.test.raises(
-            gaierror,
-            'httplib2_intercept.HTTP_WSGIInterceptorWithTimeout('
-            '"_nonexistant_domain_").connect()')
+        with py.test.raises(gaierror):
+            httplib2_intercept.HTTP_WSGIInterceptorWithTimeout(
+                    "_nonexistant_domain_").connect()
 
 
 def test_proxy_handling():

--- a/wsgi_intercept/tests/test_requests.py
+++ b/wsgi_intercept/tests/test_requests.py
@@ -36,9 +36,8 @@ def test_http_other_port():
 
 def test_bogus_domain():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=80):
-        py.test.raises(
-            ConnectionError,
-            'requests.get("http://_nonexistant_domain_")')
+        with py.test.raises(ConnectionError):
+            requests.get("http://_nonexistant_domain_")
 
 
 def test_proxy_handling():

--- a/wsgi_intercept/tests/test_urllib3.py
+++ b/wsgi_intercept/tests/test_urllib3.py
@@ -38,10 +38,8 @@ def test_http_other_port():
 
 def test_bogus_domain():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=80):
-        py.test.raises(
-            urllib3.exceptions.ProtocolError,
-            'http.request("GET", "http://_nonexistant_domain_", '
-            'retries=False)')
+        with py.test.raises(urllib3.exceptions.ProtocolError):
+            http.request("GET", "http://_nonexistant_domain_", retries=False)
 
 
 def test_proxy_handling():


### PR DESCRIPTION
httplib2 added some more kwargs, so rather than continuing
to explicitly list each one (they are ignored), use **kwargs
instead.

update some tests to work correctly with modern pytest, which
no longer allows the string-as-callable to check for exceptions.
Use py.test.raises context manager instead.

remove python versions that tox no longer supports