### PR TITLE
Don't send headers until we've read some results

### DIFF
--- a/wsgi_intercept/__init__.py
+++ b/wsgi_intercept/__init__.py
@@ -451,25 +451,6 @@ class wsgi_fake_socket:
             raise WSGIAppError(error, sys.exc_info())
         self.result = iter(app_result)
 
-        # send the headers
-
-        for k, v in self.headers:
-            if STRICT_RESPONSE_HEADERS:
-                if not (isinstance(k, str) and isinstance(v, str)):
-                    raise TypeError(
-                        "Header has a key '%s' or value '%s' "
-                        "which is not a native str." % (k, v))
-            try:
-                k = k.encode('ISO-8859-1')
-            except AttributeError:
-                pass
-            try:
-                v = v.encode('ISO-8859-1')
-            except AttributeError:
-                pass
-            self.output.write(k + b': ' + v + b"\n")
-        self.output.write(b'\n')
-
         ###
 
         # read all of the results.  the trick here is to get the *first*
@@ -485,6 +466,25 @@ class wsgi_fake_socket:
                 generator_data = next(self.result)
 
             finally:
+                # send the headers
+
+                for k, v in self.headers:
+                    if STRICT_RESPONSE_HEADERS:
+                        if not (isinstance(k, str) and isinstance(v, str)):
+                            raise TypeError(
+                                "Header has a key '%s' or value '%s' "
+                                "which is not a native str." % (k, v))
+                    try:
+                        k = k.encode('ISO-8859-1')
+                    except AttributeError:
+                        pass
+                    try:
+                        v = v.encode('ISO-8859-1')
+                    except AttributeError:
+                        pass
+                    self.output.write(k + b': ' + v + b"\n")
+                self.output.write(b'\n')
+
                 for data in self.write_results:
                     self.output.write(data)
 

--- a/wsgi_intercept/tests/test_wsgi_compliance.py
+++ b/wsgi_intercept/tests/test_wsgi_compliance.py
@@ -114,3 +114,13 @@ def test_empty_iterator():
             'http://some_hopefully_nonexistant_domain/', 'GET')
         assert app.success()
         assert content == b'second'
+
+
+def test_generator():
+    with InstalledApp(wsgi_app.generator_app, host=HOST) as app:
+        http = httplib2.Http()
+        resp, content = http.request(
+            'http://some_hopefully_nonexistant_domain/', 'GET')
+        assert app.success()
+        assert resp.get('content-type') == 'text/plain'
+        assert content == b'First generated line\nSecond generated line\n'

--- a/wsgi_intercept/tests/wsgi_app.py
+++ b/wsgi_intercept/tests/wsgi_app.py
@@ -37,3 +37,9 @@ def raises_app(environ, start_response):
 def empty_string_app(environ, start_response):
     start_response('200 OK', [('Content-type', 'text/plain')])
     return [b'', b'second']
+
+
+def generator_app(environ, start_response):
+    start_response('200 OK', [('Content-type', 'text/plain')])
+    yield b'First generated line\n'
+    yield b'Second generated line\n'


### PR DESCRIPTION
If the WSGI app is a generator function (using "yield"), then it won't
do anything at all until its first iteration, including setting headers
or calling start_response to write the status line of the response.
Turn the handle once to make sure that the app has started before
writing headers.