### PR TITLE
Correct handling of a environ keys in python2

### DIFF
--- a/wsgi_intercept/__init__.py
+++ b/wsgi_intercept/__init__.py
@@ -260,7 +260,7 @@ def make_environ(inp, host, port, script_name):
         else:
             h = k.upper()
             h = h.replace(b'-', b'_')
-            environ['HTTP_' + h.decode('ISO-8859-1')] = v
+            environ['HTTP_' + str(h.decode('ISO-8859-1'))] = v
 
         if debuglevel >= 2:
             print('HEADER:', k, v)

--- a/wsgi_intercept/tests/test_wsgiref.py
+++ b/wsgi_intercept/tests/test_wsgiref.py
@@ -1,0 +1,23 @@
+import requests
+import wsgiref.simple_server
+
+from wsgi_intercept.interceptor import RequestsInterceptor
+
+
+def load_app():
+    return wsgiref.simple_server.demo_app
+
+
+def test_wsgiref():
+    """General test that the wsgiref server behaves.
+
+    This mostly confirms that environ handling is correct in both
+    python2 and 3.
+    """
+
+    try:
+        with RequestsInterceptor(load_app, host='www.example.net', port=80):
+            r = requests.get('http://www.example.net')
+            print(r.text)
+    except Exception as exc:
+        assert False, 'wsgi ref server raised exception: %s' % exc


### PR DESCRIPTION
Both keys and values should be native str. This was
already the case for values, but not for keys. Thanks
to @nboullis for identifying the problem and the fix.

A test is added which runs a request against the wsgiref
sample app, this should help to protect against such
issues recurring.

Fixes #65