### PR TITLE
Pin urllib3 to < 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ META = {
             'pytest>=2.4',
             'httplib2',
             'requests>=2.0.1',
-            'urllib3>=1.11.0',
+            'urllib3>=1.11.0,<2.0.0',
         ],
         'docs': [
             'sphinx',

--- a/tox.ini
+++ b/tox.ini
@@ -16,14 +16,16 @@ commands =
 [testenv:docs]
 deps = .[docs]
        httplib2
+       sphinx
 commands =
-    python setup.py build_sphinx
-whitelist_externals =
+    rm -rf build/sphinx
+    sphinx-build docs build/sphinx
+allowlist_externals =
     rm
 
 [testenv:readme]
 deps = .
-whitelist_externals = bash
+allowlist_externals = bash
 commands = bash -c "python -c 'import sys, wsgi_intercept; sys.stdout.write(wsgi_intercept.__doc__)' > README.rst"
 
 [flake8]

--- a/wsgi_intercept/__init__.py
+++ b/wsgi_intercept/__init__.py
@@ -115,7 +115,7 @@ it into all of the *other* Python Web testing frameworks.
 The Python 2 version of wsgi-intercept was the result. Kumar McMillan
 later took over maintenance.
 
-The current version is tested with Python 2.7, 3.5-3.8, and pypy and pypy3.
+The current version is tested with Python 2.7, 3.5-3.11, and pypy and pypy3.
 It was assembled by `Chris Dent`_. Testing and documentation improvements
 from `Sasha Hart`_.
 


### PR DESCRIPTION
2.0.0 introduces several changes that we can accomodate, eventually,
but for the time we need to prevent general failures.