### PR TITLE
Include tox.ini in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include LICENSE Makefile
+include LICENSE Makefile tox.ini
 recursive-include docs *


### PR DESCRIPTION
While building source downstream in Fedora with pyproject-rpm-macros I noticed tox.ini was not in tarball. We need it in order to take avantage of macro like %tox [1] to run the unit tests or build the doc. Until now, we are copying/pasting the commands in the SPEC file [2].

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_tox
[2] https://src.fedoraproject.org/rpms/python-wsgi_intercept/blob/rawhide/f/python-wsgi_intercept.spec#_69