### PR TITLE
Support Python 3.12

### DIFF
--- a/wsgi_intercept/_urllib3.py
+++ b/wsgi_intercept/_urllib3.py
@@ -30,6 +30,9 @@ def make_urllib3_override(HTTPConnectionPool, HTTPSConnectionPool,
             kwargs.pop('socket_options', None)
             kwargs.pop('key_password', None)
             kwargs.pop('server_hostname', None)
+            if sys.version_info > (3, 12):
+                kwargs.pop('key_file', None)
+                kwargs.pop('cert_file', None)
             WSGI_HTTPSConnection.__init__(self, *args, **kwargs)
             HTTPSConnection.__init__(self, *args, **kwargs)
 


### PR DESCRIPTION
Remove the keyfile and certfile parameters from the [ftplib](https://docs.python.org/dev/library/ftplib.html#module-ftplib), [imaplib](https://docs.python.org/dev/library/imaplib.html#module-imaplib), [poplib](https://docs.python.org/dev/library/poplib.html#module-poplib) and [smtplib](https://docs.python.org/dev/library/smtplib.html#module-smtplib) modules, and the key_file, cert_file and check_hostname parameters from the [http.client](https://docs.python.org/dev/library/http.client.html#module-http.client) module, all deprecated since Python 3.6. Use the context parameter (ssl_context in [imaplib](https://docs.python.org/dev/library/imaplib.html#module-imaplib)) instead. (Contributed by Victor Stinner in [gh-94172](https://github.com/python/cpython/issues/94172).)