### PR TITLE
Update urllib3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ threads to test your Web app.
 Supported Libaries
 ==================
 
-``wsgi_intercept`` works with a variety of HTTP clients in Python 2.7,
-3.5 and beyond, and in pypy.
+``wsgi_intercept`` works with a variety of HTTP clients in Python 3.7
+and beyond, and in pypy.
 
 * urllib2
 * urllib.request
@@ -22,7 +22,7 @@ Supported Libaries
 * http.client
 * httplib2
 * requests
-* urllib3 (<2.0.0, urllib3 2 support is in progress)
+* urllib3
 
 How Does It Work?
 =================
@@ -88,13 +88,8 @@ Packages Intercepted
 Unfortunately each of the HTTP client libraries use their own specific
 mechanism for making HTTP call-outs, so individual implementations are
 needed. At this time there are implementations for ``httplib2``,
-``urllib3`` (<2.0.0) and ``requests`` in both Python 2 and 3, ``urllib2`` and
-``httplib`` in Python 2 and ``urllib.request`` and ``http.client``
+``urllib3``, ``requests``, ``urllib.request``, and ``http.client``
 in Python 3.
-
-If you are using Python 2 and need support for a different HTTP
-client, require a version of ``wsgi_intercept<0.6``. Earlier versions
-include support for ``webtest``, ``webunit`` and ``zope.testbrowser``.
 
 The best way to figure out how to use interception is to inspect
 `the tests`_. More comprehensive documentation available upon
@@ -115,9 +110,8 @@ it into all of the *other* Python Web testing frameworks.
 The Python 2 version of wsgi-intercept was the result. Kumar McMillan
 later took over maintenance.
 
-The current version is tested with Python 2.7, 3.5-3.11, and pypy and pypy3.
-It was assembled by `Chris Dent`_. Testing and documentation improvements
-from `Sasha Hart`_.
+The current version is tested with Python 3.7-3.12, and pypy3. It was assembled
+by `Chris Dent`_. Testing and documentation improvements from `Sasha Hart`_.
 
 .. _"best Web testing framework":
      http://blog.ianbicking.org/best-of-the-web-app-test-frameworks.html

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Packages Intercepted
 Unfortunately each of the HTTP client libraries use their own specific
 mechanism for making HTTP call-outs, so individual implementations are
 needed. At this time there are implementations for ``httplib2``,
-``urllib3``, ``requests``, ``urllib.request``, and ``http.client``
+``urllib3``, ``requests``, ``urllib.request`` and ``http.client``
 in Python 3.
 
 The best way to figure out how to use interception is to inspect
@@ -110,8 +110,9 @@ it into all of the *other* Python Web testing frameworks.
 The Python 2 version of wsgi-intercept was the result. Kumar McMillan
 later took over maintenance.
 
-The current version is tested with Python 3.7-3.12, and pypy3. It was assembled
-by `Chris Dent`_. Testing and documentation improvements from `Sasha Hart`_.
+The current version is tested with Python 3.7-3.12, and pypy3.  It was
+assembled by `Chris Dent`_. Testing and documentation improvements from
+`Sasha Hart`_.
 
 .. _"best Web testing framework":
      http://blog.ianbicking.org/best-of-the-web-app-test-frameworks.html

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,6 @@ Environment :: Web Environment
 Intended Audience :: Developers
 License :: OSI Approved :: MIT License
 Operating System :: OS Independent
-Programming Language :: Python :: 2
-Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
@@ -36,15 +34,13 @@ META = {
     'license': 'MIT License',
     'classifiers': CLASSIFIERS,
     'packages': find_packages(),
-    'install_requires': [
-        'six',
-    ],
+    'python_requires': '>=3',
     'extras_require': {
         'testing': [
             'pytest>=2.4',
             'httplib2',
             'requests>=2.0.1',
-            'urllib3>=1.11.0,<2.0.0',
+            'urllib3<2.0.0',
         ],
         'docs': [
             'sphinx',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ META = {
             'pytest>=2.4',
             'httplib2',
             'requests>=2.0.1',
-            'urllib3<2.0.0',
+            'urllib3>=2.0.0',
         ],
         'docs': [
             'sphinx',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py27,py35,py36,py37,py38,py39,py310,py311,py312,pypy,pep8,docs,readme
+envlist = py37,py38,py39,py310,py311,py312,pypy,pep8,docs,readme
 
 [testenv]
 deps = .[testing]
-commands = py.test --tb=short wsgi_intercept/tests
+commands = py.test --tb=short wsgi_intercept/tests {posargs}
 passenv = WSGI_INTERCEPT_*
 
 [testenv:pep8]

--- a/wsgi_intercept/__init__.py
+++ b/wsgi_intercept/__init__.py
@@ -578,6 +578,11 @@ class WSGI_HTTPSConnection(HTTPSConnection, WSGI_HTTPConnection):
     Intercept all traffic to certain hosts & redirect into a WSGI
     application object.
     """
+
+    def __init__(self, *args, **kwargs):
+        print("getting %s ::: %s" % (args, kwargs))
+        super().__init__(*args, **kwargs)
+
     def get_app(self, host, port):
         """
         Return the app object for the given (host, port).

--- a/wsgi_intercept/__init__.py
+++ b/wsgi_intercept/__init__.py
@@ -13,8 +13,8 @@ threads to test your Web app.
 Supported Libaries
 ==================
 
-``wsgi_intercept`` works with a variety of HTTP clients in Python 2.7,
-3.7 and beyond, and in pypy.
+``wsgi_intercept`` works with a variety of HTTP clients in Python 3.7
+and beyond, and in pypy.
 
 * urllib2
 * urllib.request
@@ -22,7 +22,7 @@ Supported Libaries
 * http.client
 * httplib2
 * requests
-* urllib3 (<2.0.0, urllib3 2 support is in progress)
+* urllib3
 
 How Does It Work?
 =================
@@ -88,13 +88,8 @@ Packages Intercepted
 Unfortunately each of the HTTP client libraries use their own specific
 mechanism for making HTTP call-outs, so individual implementations are
 needed. At this time there are implementations for ``httplib2``,
-``urllib3`` (<2.0.0) and ``requests`` in both Python 2 and 3, ``urllib2`` and
-``httplib`` in Python 2 and ``urllib.request`` and ``http.client``
+``urllib3``, ``requests``, ``urllib.request`` and ``http.client``
 in Python 3.
-
-If you are using Python 2 and need support for a different HTTP
-client, require a version of ``wsgi_intercept<0.6``. Earlier versions
-include support for ``webtest``, ``webunit`` and ``zope.testbrowser``.
 
 The best way to figure out how to use interception is to inspect
 `the tests`_. More comprehensive documentation available upon
@@ -115,9 +110,9 @@ it into all of the *other* Python Web testing frameworks.
 The Python 2 version of wsgi-intercept was the result. Kumar McMillan
 later took over maintenance.
 
-The current version is tested with Python 2.7, 3.5-3.11, and pypy and pypy3.
-It was assembled by `Chris Dent`_. Testing and documentation improvements
-from `Sasha Hart`_.
+The current version is tested with Python 3.7-3.12, and pypy3.  It was
+assembled by `Chris Dent`_. Testing and documentation improvements from
+`Sasha Hart`_.
 
 .. _"best Web testing framework":
      http://blog.ianbicking.org/best-of-the-web-app-test-frameworks.html
@@ -546,7 +541,6 @@ class WSGI_HTTPConnection(HTTPConnection):
                 args = args[0:2]
             super().__init__(*args, **kwargs)
 
-
     def get_app(self, host, port):
         """
         Return the app object for the given (host, port).
@@ -599,7 +593,6 @@ class WSGI_HTTPSConnection(HTTPSConnection, WSGI_HTTPConnection):
     Intercept all traffic to certain hosts & redirect into a WSGI
     application object.
     """
-
 
     def get_app(self, host, port):
         """

--- a/wsgi_intercept/__init__.py
+++ b/wsgi_intercept/__init__.py
@@ -144,15 +144,9 @@ import sys
 import traceback
 from io import BytesIO
 
-# Don't use six here because it is unquote_to_bytes that we want in
-# Python 3.
-try:
-    from urllib.parse import unquote_to_bytes as url_unquote
-except ImportError:
-    from urllib import unquote as url_unquote
+from urllib.parse import unquote_to_bytes as url_unquote
 
-import six
-from six.moves.http_client import HTTPConnection, HTTPSConnection
+from http.client import HTTPConnection, HTTPSConnection
 
 
 # Set this to True to cause response headers from the intercepted
@@ -227,8 +221,7 @@ def make_environ(inp, host, port, script_name):
     environ = {}
 
     method_line = inp.readline()
-    if six.PY3:
-        method_line = method_line.decode('ISO-8859-1')
+    method_line = method_line.decode('ISO-8859-1')
 
     content_type = None
     content_length = None
@@ -302,13 +295,11 @@ def make_environ(inp, host, port, script_name):
     # fill out our dictionary.
     #
 
-    # In Python3 turn the bytes of the path info into a string of
-    # latin-1 code points, because that's what the spec says we must
-    # do to be like a server. Later various libraries will be forced
-    # to decode and then reencode to get the UTF-8 that everyone
-    # wants.
-    if six.PY3:
-        path_info = path_info.decode('latin-1')
+    # Turn the bytes of the path info into a string of latin-1 code points,
+    # because that's what the spec says we must do to be like a server. Later
+    # various libraries will be forced to decode and then reencode to get the
+    # UTF-8 that everyone wants.
+    path_info = path_info.decode('latin-1')
 
     environ.update({
         "wsgi.version": (1, 0),
@@ -633,7 +624,7 @@ class WSGI_HTTPSConnection(HTTPSConnection, WSGI_HTTPConnection):
                             else:
                                 self._context.verify_mode = ssl.VerifyMode[
                                     self.cert_reqs]
-                        elif isinstance(self.cert_reqs, six.string_types):
+                        elif isinstance(self.cert_reqs, str):
                             # Support for Python3.5 and below
                             self._context.verify_mode = getattr(ssl,
                                     self.cert_reqs,

--- a/wsgi_intercept/__init__.py
+++ b/wsgi_intercept/__init__.py
@@ -526,6 +526,23 @@ class WSGI_HTTPConnection(HTTPConnection):
     Intercept all traffic to certain hosts & redirect into a WSGI
     application object.
     """
+
+    def __init__(self, *args, **kwargs):
+        print(f"args1 is {args}, kwargs is {kwargs}")
+        if 'host' in kwargs:
+            host = kwargs.pop('host')
+            if 'port' in kwargs:
+                port = kwargs.pop('port')
+            else:
+                port = None
+            print(f"args2 is {args}, kwargs is {kwargs}")
+            super().__init__(host, port, *args, **kwargs)
+        else:
+            if len(args) > 2:
+                args = args[0:2]
+            super().__init__(*args, **kwargs)
+
+
     def get_app(self, host, port):
         """
         Return the app object for the given (host, port).
@@ -579,9 +596,6 @@ class WSGI_HTTPSConnection(HTTPSConnection, WSGI_HTTPConnection):
     application object.
     """
 
-    def __init__(self, *args, **kwargs):
-        print("getting %s ::: %s" % (args, kwargs))
-        super().__init__(*args, **kwargs)
 
     def get_app(self, host, port):
         """

--- a/wsgi_intercept/_urllib3.py
+++ b/wsgi_intercept/_urllib3.py
@@ -32,7 +32,6 @@ def make_urllib3_override(HTTPConnectionPool, HTTPSConnectionPool,
 
     class HTTP_WSGIInterceptor(WSGI_HTTPConnection, HTTPConnection):
         def __init__(self, *args, **kwargs):
-            print(f"http pre: {args} ::: {kwargs}")
             for kw in HTTP_KEYWORD_POPS:
                 kwargs.pop(kw, None)
             WSGI_HTTPConnection.__init__(self, *args, **kwargs)
@@ -42,19 +41,14 @@ def make_urllib3_override(HTTPConnectionPool, HTTPSConnectionPool,
         is_verified = True
 
         def __init__(self, *args, **kwargs):
-            print(f"https pre: {args} ::: {kwargs}")
+            print(f"{args}:::{kwargs}")
             for kw in HTTPS_KEYWORD_POPS:
                 kwargs.pop(kw, None)
             if sys.version_info > (3, 12):
                 kwargs.pop('key_file', None)
                 kwargs.pop('cert_file', None)
-            print(f"https post: {args} ::: {kwargs}")
-            host = kwargs.pop('host')
-            port = kwargs.pop('port')
-            WSGI_HTTPSConnection.__init__(self, host, port, *args, **kwargs)
-            print("after wsgi")
+            WSGI_HTTPSConnection.__init__(self, *args, **kwargs)
             HTTPSConnection.__init__(self, *args, **kwargs)
-            print("after https")
 
     def install():
         if 'http_proxy' in os.environ or 'https_proxy' in os.environ:

--- a/wsgi_intercept/_urllib3.py
+++ b/wsgi_intercept/_urllib3.py
@@ -42,6 +42,8 @@ def make_urllib3_override(HTTPConnectionPool, HTTPSConnectionPool,
 
         def __init__(self, *args, **kwargs):
             print(f"{args}:::{kwargs}")
+            if 'cert_reqs' in kwargs and kwargs['cert_reqs'] is not None:
+                self._intercept_cert_reqs = kwargs.pop("cert_reqs")
             for kw in HTTPS_KEYWORD_POPS:
                 kwargs.pop(kw, None)
             if sys.version_info > (3, 12):

--- a/wsgi_intercept/_urllib3.py
+++ b/wsgi_intercept/_urllib3.py
@@ -32,6 +32,7 @@ def make_urllib3_override(HTTPConnectionPool, HTTPSConnectionPool,
 
     class HTTP_WSGIInterceptor(WSGI_HTTPConnection, HTTPConnection):
         def __init__(self, *args, **kwargs):
+            print(f"http pre: {args} ::: {kwargs}")
             for kw in HTTP_KEYWORD_POPS:
                 kwargs.pop(kw, None)
             WSGI_HTTPConnection.__init__(self, *args, **kwargs)
@@ -41,15 +42,19 @@ def make_urllib3_override(HTTPConnectionPool, HTTPSConnectionPool,
         is_verified = True
 
         def __init__(self, *args, **kwargs):
-            print(f"pre: {args} ::: {kwargs}")
+            print(f"https pre: {args} ::: {kwargs}")
             for kw in HTTPS_KEYWORD_POPS:
                 kwargs.pop(kw, None)
             if sys.version_info > (3, 12):
                 kwargs.pop('key_file', None)
                 kwargs.pop('cert_file', None)
-            print(f"post: {args} ::: {kwargs}")
-            WSGI_HTTPSConnection.__init__(self, *args, **kwargs)
+            print(f"https post: {args} ::: {kwargs}")
+            host = kwargs.pop('host')
+            port = kwargs.pop('port')
+            WSGI_HTTPSConnection.__init__(self, host, port, *args, **kwargs)
+            print("after wsgi")
             HTTPSConnection.__init__(self, *args, **kwargs)
+            print("after https")
 
     def install():
         if 'http_proxy' in os.environ or 'https_proxy' in os.environ:

--- a/wsgi_intercept/_urllib3.py
+++ b/wsgi_intercept/_urllib3.py
@@ -27,6 +27,7 @@ HTTPS_KEYWORD_POPS = HTTP_KEYWORD_POPS + [
     'ssl_maximum_version',
 ]
 
+
 def make_urllib3_override(HTTPConnectionPool, HTTPSConnectionPool,
                           HTTPConnection, HTTPSConnection):
 

--- a/wsgi_intercept/_urllib3.py
+++ b/wsgi_intercept/_urllib3.py
@@ -42,7 +42,6 @@ def make_urllib3_override(HTTPConnectionPool, HTTPSConnectionPool,
         is_verified = True
 
         def __init__(self, *args, **kwargs):
-            print(f"{args}:::{kwargs}")
             if 'cert_reqs' in kwargs and kwargs['cert_reqs'] is not None:
                 self._intercept_cert_reqs = kwargs.pop("cert_reqs")
             for kw in HTTPS_KEYWORD_POPS:

--- a/wsgi_intercept/http_client_intercept.py
+++ b/wsgi_intercept/http_client_intercept.py
@@ -1,23 +1,14 @@
 """Intercept HTTP connections that use httplib (Py2) or http.client (Py3).
 """
 
-try:
-    import http.client as http_lib
-except ImportError:
-    import httplib as http_lib
+import http.client as http_lib
 
 from . import WSGI_HTTPConnection, WSGI_HTTPSConnection
 
-try:
-    from http.client import (
-            HTTPConnection as OriginalHTTPConnection,
-            HTTPSConnection as OriginalHTTPSConnection
-    )
-except ImportError:
-    from httplib import (
-            HTTPConnection as OriginalHTTPConnection,
-            HTTPSConnection as OriginalHTTPSConnection
-    )
+from http.client import (
+        HTTPConnection as OriginalHTTPConnection,
+        HTTPSConnection as OriginalHTTPSConnection
+)
 
 
 class HTTP_WSGIInterceptor(WSGI_HTTPConnection, http_lib.HTTPConnection):

--- a/wsgi_intercept/interceptor.py
+++ b/wsgi_intercept/interceptor.py
@@ -4,7 +4,7 @@
 from importlib import import_module
 from uuid import uuid4
 
-from six.moves.urllib import parse as urlparse
+from urllib import parse as urlparse
 
 import wsgi_intercept
 

--- a/wsgi_intercept/tests/test_http_client.py
+++ b/wsgi_intercept/tests/test_http_client.py
@@ -2,10 +2,7 @@ import pytest
 from wsgi_intercept import http_client_intercept, WSGIAppError
 from . import wsgi_app
 from .install import installer_class, skipnetwork
-try:
-    import http.client as http_lib
-except ImportError:
-    import httplib as http_lib
+import http.client as http_lib
 
 HOST = 'some_hopefully_nonexistant_domain'
 

--- a/wsgi_intercept/tests/test_interceptor.py
+++ b/wsgi_intercept/tests/test_interceptor.py
@@ -11,13 +11,9 @@ import pytest
 import requests
 import urllib3
 from httplib2 import Http, ServerNotFoundError
-# don't use six as the monkey patching gets confused
-try:
-    import http.client as http_client
-except ImportError:
-    import httplib as http_client
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.error import URLError
+import http.client as http_client
+from urllib.request import urlopen
+from urllib.error import URLError
 
 from wsgi_intercept.interceptor import (
     Interceptor, HttpClientInterceptor, Httplib2Interceptor,

--- a/wsgi_intercept/tests/test_response_headers.py
+++ b/wsgi_intercept/tests/test_response_headers.py
@@ -10,7 +10,6 @@ not the other way round. Let's write some tests to fix that.
 
 import pytest
 import requests
-import six
 
 import wsgi_intercept
 from wsgi_intercept.interceptor import RequestsInterceptor
@@ -56,10 +55,7 @@ def test_header_app():
 def test_encoding_violation():
     """If the header is unicode we expect boom."""
     header_key = 'request-id'
-    if six.PY2:
-        header_value = u'alpha'
-    else:
-        header_value = b'alpha'
+    header_value = b'alpha'
     # we expect our http library to give us a str
     returned_header = 'alpha'
 

--- a/wsgi_intercept/tests/test_urllib.py
+++ b/wsgi_intercept/tests/test_urllib.py
@@ -3,10 +3,7 @@ import pytest
 from wsgi_intercept import urllib_intercept, WSGIAppError
 from . import wsgi_app
 from .install import installer_class, skipnetwork
-try:
-    import urllib.request as url_lib
-except ImportError:
-    import urllib2 as url_lib
+import urllib.request as url_lib
 
 HOST = 'some_hopefully_nonexistant_domain'
 

--- a/wsgi_intercept/tests/test_urllib3.py
+++ b/wsgi_intercept/tests/test_urllib3.py
@@ -54,7 +54,7 @@ def test_proxy_handling():
     del os.environ['http_proxy']
 
 
-def test_https():
+def test_https_meo():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
         resp = http.request(
             'GET', 'https://some_hopefully_nonexistant_domain:443/')

--- a/wsgi_intercept/tests/test_urllib3.py
+++ b/wsgi_intercept/tests/test_urllib3.py
@@ -54,7 +54,7 @@ def test_proxy_handling():
     del os.environ['http_proxy']
 
 
-def test_https_meo():
+def test_https():
     with InstalledApp(wsgi_app.simple_app, host=HOST, port=443) as app:
         resp = http.request(
             'GET', 'https://some_hopefully_nonexistant_domain:443/')

--- a/wsgi_intercept/tests/test_wsgi_compliance.py
+++ b/wsgi_intercept/tests/test_wsgi_compliance.py
@@ -1,9 +1,6 @@
 import sys
 import pytest
-try:
-    from urllib.parse import unquote
-except ImportError:
-    from urllib import unquote
+from urllib.parse import unquote
 from wsgi_intercept import httplib2_intercept
 from . import wsgi_app
 from .install import installer_class

--- a/wsgi_intercept/tests/wsgi_app.py
+++ b/wsgi_intercept/tests/wsgi_app.py
@@ -4,11 +4,6 @@ Simple WSGI applications for testing.
 
 from pprint import pformat
 
-try:
-    bytes
-except ImportError:
-    bytes = str
-
 
 def simple_app(environ, start_response):
     """Simplest possible application object"""

--- a/wsgi_intercept/urllib3_intercept.py
+++ b/wsgi_intercept/urllib3_intercept.py
@@ -1,8 +1,5 @@
 """Intercept HTTP connections that use
 `urllib3 <https://urllib3.readthedocs.org/>`_.
-
-Note that currently only urllib3 <2.0.0 is supported. 2.0.0 support
-is in progress.
 """
 
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool

--- a/wsgi_intercept/urllib_intercept.py
+++ b/wsgi_intercept/urllib_intercept.py
@@ -4,10 +4,7 @@ aka urllib2 (Python 2).
 
 import os
 
-try:
-    import urllib.request as url_lib
-except ImportError:
-    import urllib2 as url_lib
+import urllib.request as url_lib
 
 from . import WSGI_HTTPConnection, WSGI_HTTPSConnection
 


### PR DESCRIPTION
This is a draft attempt to update to urllib3 version 2, but the results are potentially too fragile to be considered.

The fundamental problem is caused by changing constraints in the signatures of `__init__` of the super classes. Which gets quite complicated.

urllib3 version introduces use of the `*` argument in the signature, constraining what must be a named parameter.