### PR TITLE
Update argument processing for modern requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Supported Libaries
 ==================
 
 ``wsgi_intercept`` works with a variety of HTTP clients in Python 2.7,
-3.5 and beyond, and in pypy.
+3.7 and beyond, and in pypy.
 
 * urllib2
 * urllib.request

--- a/wsgi_intercept/_urllib3.py
+++ b/wsgi_intercept/_urllib3.py
@@ -30,6 +30,7 @@ def make_urllib3_override(HTTPConnectionPool, HTTPSConnectionPool,
             kwargs.pop('socket_options', None)
             kwargs.pop('key_password', None)
             kwargs.pop('server_hostname', None)
+            kwargs.pop('ssl_context', None)
             if sys.version_info > (3, 12):
                 kwargs.pop('key_file', None)
                 kwargs.pop('cert_file', None)


### PR DESCRIPTION
Requests now passes around an ssl_context, at least some of the time.