### PR TITLE
Remove python 3.7 support, add python 3.13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,8 +13,6 @@ jobs:
                       env: pep8
                     - python: 3.9
                       env: docs
-                    - python: 3.7
-                      env: py37
                     - python: 3.8
                       env: py38
                     - python: 3.9
@@ -25,6 +23,8 @@ jobs:
                       env: py311
                     - python: "3.12"
                       env: py312
+                    - python: "3.13"
+                      env: py313
                     - python: pypy-3.8
                       env: pypy3
         name: ${{ matrix.env }} on Python ${{ matrix.python }}

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Supported Libaries
 ==================
 
 ``wsgi_intercept`` works with a variety of HTTP clients in Python 2.7,
-3.7 and beyond, and in pypy.
+3.8 and beyond, and in pypy.
 
 * urllib2
 * urllib.request

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,12 @@ Operating System :: OS Independent
 Programming Language :: Python :: 2
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
 Programming Language :: Python :: 3.12
+Programming Language :: Python :: 3.13
 Topic :: Internet :: WWW/HTTP :: WSGI
 Topic :: Software Development :: Testing
 """.strip().splitlines()

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py27,py35,py36,py37,py38,py39,py310,py311,py312,pypy,pep8,docs,readme
+envlist = py27,py35,py36,py38,py39,py310,py311,py312,py313,pypy,pep8,docs,readme
 
 [testenv]
 deps = .[testing]

--- a/wsgi_intercept/__init__.py
+++ b/wsgi_intercept/__init__.py
@@ -14,7 +14,7 @@ Supported Libaries
 ==================
 
 ``wsgi_intercept`` works with a variety of HTTP clients in Python 2.7,
-3.7 and beyond, and in pypy.
+3.8 and beyond, and in pypy.
 
 * urllib2
 * urllib.request


### PR DESCRIPTION
This is mostly a matter of what is being tested.
3.7 should continue to work, but it is no longer
easy to test so we no longer claim support.